### PR TITLE
Package updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
         PIP_ARGS=( --pip-arg={-r,../specs/macos/requirements.txt,Orange3==$BUILD_COMMIT} );
     fi
   - |-
-    ./scripts/macos/build-macos-app.sh "${PIP_ARGS[@]}" "$APP"
+    ./scripts/macos/build-macos-app.sh "${PIP_ARGS[@]}" --python-version=3.6.8 "$APP"
   - |-
     ./scripts/macos/create-dmg-installer.sh --app "$APP" dist/Orange3.dmg
   - |-

--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - setuptools    >=36.3
-    - numpy         >=1.13.0
+    - numpy         >=1.16.0
     - scipy
     - scikit-learn  >=0.20.0
     - bottleneck    >=1.2.1

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -18,7 +18,7 @@ PyQt5~=5.9.1
 docutils==0.13.1
 pip~=19.0
 pyqtgraph==0.10.0
-xlrd==1.0.0
+xlrd~=1.2
 xlsxwriter
 serverfiles
 opentsne~=0.3.0

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -19,7 +19,7 @@ PyQt5~=5.9.1
 docutils==0.13.1
 pip~=19.0
 pyqtgraph==0.10.0
-xlrd==1.0.0
+xlrd~=1.2
 xlsxwriter
 serverfiles
 opentsne~=0.3.0


### PR DESCRIPTION
xlrd updated so that it support supports python 3.7 (which we will likely soon update to). See biolab/orange3-single-cell#365

Also updated Python in mac dmg to the latest version that worked with python-framework.sh (3.6.9 could not be downloaded).
