### PR TITLE
Update PyQt to 5.12

### DIFF
--- a/ci/appveyor-conda-build.bat
+++ b/ci/appveyor-conda-build.bat
@@ -47,7 +47,7 @@ if "%CONDA_SPEC_FILE%" == "" (
                  scipy=1.2.* ^
                  scikit-learn=0.21.* ^
                  bottleneck=1.2.* ^
-                 pyqt=5.9.* ^
+                 pyqt=5.12.* ^
                  Orange3=%VERSION% ^
         || exit /b !ERRORLEVEL!
 

--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -49,8 +49,8 @@ requirements:
     - matplotlib    >=2.0.0
     - opentsne      >=0.3.0
     - pandas
-    - orange-canvas-core
-    - orange-widget-base
+    - orange-canvas-core >=0.1.7
+    - orange-widget-base >=4.1.0
     - pyyaml
 
 test:

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -14,7 +14,8 @@ chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
 AnyQt>=0.0.8
-PyQt5~=5.9.1
+PyQt5~=5.12.3
+pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
 pyqtgraph==0.10.0

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -15,7 +15,8 @@ keyrings.alt==2.2
 pywin32-ctypes==0.0.1
 pyreadline==2.1
 AnyQt~=0.0.8
-PyQt5~=5.9.1
+PyQt5~=5.12.3
+pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
 pyqtgraph==0.10.0


### PR DESCRIPTION
Now that conda-forge has Qt 5.12, we can actually update.

In Orange command prompt on Windows Orange 3.23 install I did `conda install icu=64.2 pyqt=5.12.3 qt=5.12.5`. Everything seemed normal and widget tests passed.

On Mac I tried `pip install ptqt5==5.12.3 pyqtwebengine==5.12`. Tests passed.

A single unrelated (mssql) test fails.