### PR TITLE
Releases/pre 3.27.0 - updated requirements

### DIFF
--- a/ci/appveyor-conda-build.bat
+++ b/ci/appveyor-conda-build.bat
@@ -54,8 +54,8 @@ if "%CONDA_SPEC_FILE%" == "" (
                  python=%PYTHON_VERSION% ^
                  numpy=1.16.* ^
                  scipy=1.2.* ^
-                 scikit-learn=0.22.* ^
-                 bottleneck=1.2.* ^
+                 scikit-learn=0.23.* ^
+                 bottleneck=1.3.* ^
                  pyqt=5.12.* ^
                  Orange3=%VERSION% ^
         || exit /b !ERRORLEVEL!

--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -31,16 +31,16 @@ requirements:
     - setuptools    >=36.3
     - numpy         >=1.16.0
     - scipy
-    - scikit-learn  >=0.22.0
-    - bottleneck    >=1.2.1
-    - chardet       >=2.3.0
+    - scikit-learn  >=0.23.2
+    - bottleneck    >=1.3.0
+    - chardet       >=3.0.2
     - docutils
     - xlrd          >=0.9.2
     - xlsxwriter
     - keyring
     - keyrings.alt  # for alternative keyring implementations
     - pyqt          ~=5.12.0
-    - pyqtgraph     >=0.11.0
+    - pyqtgraph     ==0.11.0
     - anyqt         >=0.0.8
     - joblib        >=0.9.4
     - python.app    # [osx]
@@ -49,12 +49,12 @@ requirements:
     - matplotlib    >=2.0.0
     - opentsne      >=0.4.3
     - pandas
-    - orange-canvas-core >=0.1.15
-    - orange-widget-base >=4.6.0
+    - orange-canvas-core >=0.1.16
+    - orange-widget-base >=4.8.1
     - pyyaml
     - openpyxl
     - baycomp    >=1.0.2
-    - httpx      =0.12.*
+    - httpx      ==0.14.*
 
     # cachecontrol 0.12.5 is incompatible with msgpack-python=1.0
     - cachecontrol   >=0.12.6

--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - keyring
     - keyrings.alt  # for alternative keyring implementations
     - pyqt          ~=5.12.0
-    - pyqtgraph     >=0.10.0
+    - pyqtgraph     >=0.11.0
     - anyqt         >=0.0.8
     - joblib        >=0.9.4
     - python.app    # [osx]

--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - python-louvain >=0.13
     - matplotlib    >=2.0.0
     - opentsne      >=0.4.3
-    - pandas
+    - pandas        ==1.1.*
     - orange-canvas-core >=0.1.16
     - orange-widget-base >=4.8.1
     - pyyaml

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -16,7 +16,7 @@ keyrings.alt==2.2
 AnyQt~=0.0.8
 PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
-docutils==0.13.1
+docutils~=0.16.0
 pip~=19.0
 pyqtgraph==0.11.0
 xlrd~=1.2
@@ -24,3 +24,4 @@ xlsxwriter
 serverfiles
 opentsne~=0.4.3
 python-louvain>=0.13
+pandas~=1.1.0

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -18,7 +18,7 @@ PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
-pyqtgraph==0.10.0
+pyqtgraph>=0.11.0
 xlrd~=1.2
 xlsxwriter
 serverfiles

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -5,20 +5,20 @@
 
 --only-binary numpy,scipy,scikit-learn,PyQt5,opentsne
 
-numpy~=1.16.0
-scipy~=1.2.0
-scikit-learn~=0.22.0
-bottleneck~=1.2.0
+numpy~=1.19.0
+scipy~=1.5.0
+scikit-learn~=0.23.2
+bottleneck~=1.3.0
 joblib==0.11
 chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
-AnyQt>=0.0.8
+AnyQt~=0.0.8
 PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
-pyqtgraph>=0.11.0
+pyqtgraph==0.11.0
 xlrd~=1.2
 xlsxwriter
 serverfiles

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -17,7 +17,7 @@ pyreadline==2.1
 AnyQt~=0.0.8
 PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
-docutils==0.13.1
+docutils~=0.16.0
 pip~=19.0
 pyqtgraph==0.11.0
 xlrd~=1.2
@@ -25,4 +25,4 @@ xlsxwriter
 serverfiles
 opentsne~=0.4.3
 python-louvain>=0.13
-pandas~=0.25
+pandas~=1.1.0

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -5,10 +5,10 @@
 
 --only-binary numpy,scipy,scikit-learn,PyQt5,opentsne
 
-numpy~=1.16.0
-scipy~=1.2.0
-scikit-learn~=0.22.0
-bottleneck~=1.2.0
+numpy~=1.19.0
+scipy~=1.5.0
+scikit-learn~=0.23.2
+bottleneck~=1.3.0
 chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
@@ -19,7 +19,7 @@ PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
-pyqtgraph>=0.11.0
+pyqtgraph==0.11.0
 xlrd~=1.2
 xlsxwriter
 serverfiles

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -19,7 +19,7 @@ PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils==0.13.1
 pip~=19.0
-pyqtgraph==0.10.0
+pyqtgraph>=0.11.0
 xlrd~=1.2
 xlsxwriter
 serverfiles


### PR DESCRIPTION
I raised some dependencies version and made them equal around all three files (conda-recipe/meta.yaml, win/PY36.txt, macos/requirements.txt). I increased the version for all requirements that looks OK and pinned versions are not newly released. @ales-erjavec and @markotoplak can you check whether it is OK?

I am not sure what to make with `docutils==0.13.1` (version from 2016) - is there any reason why is it pinned? I am using the newest version for some time now already.
Also, pandas is pinned to version lower than 1.0 on windows only. Is there any reason behind it? 