### PR TITLE
Upstream 3.27.1-bigsur changes

### DIFF
--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - keyrings.alt  # for alternative keyring implementations
     - pyqt          ~=5.12.0
     - pyqtgraph     ==0.11.0
-    - anyqt         >=0.0.8
+    - anyqt         >=0.0.11
     - joblib        >=0.9.4
     - python.app    # [osx]
     - serverfiles
@@ -49,7 +49,7 @@ requirements:
     - matplotlib    >=2.0.0
     - opentsne      >=0.4.3
     - pandas        ==1.1.*
-    - orange-canvas-core >=0.1.16
+    - orange-canvas-core >=0.1.18
     - orange-widget-base >=4.8.1
     - pyyaml
     - openpyxl

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -14,8 +14,11 @@ chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
 AnyQt~=0.0.11
-PyQt5~=5.12.3
-pyqtwebengine~=5.12.1
+
+# PyQt==5.12.3 requires python compiled for MacOS 10.13+ to work on MacOS 11.0
+PyQt5==5.12.2
+pyqtwebengine==5.12.1
+
 docutils~=0.16.0
 pip~=19.0
 pyqtgraph==0.11.0

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -13,7 +13,7 @@ joblib==0.11
 chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
-AnyQt~=0.0.8
+AnyQt~=0.0.11
 PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils~=0.16.0

--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -14,7 +14,7 @@ keyring==10.3.1
 keyrings.alt==2.2
 pywin32-ctypes==0.0.1
 pyreadline==2.1
-AnyQt~=0.0.8
+AnyQt~=0.0.11
 PyQt5~=5.12.3
 pyqtwebengine~=5.12.1
 docutils~=0.16.0


### PR DESCRIPTION
Upstream changes for 3.27.1:
- new anyqt dependencies 
- pin for PyQt 5.12.2 for support on Big Sur on macs

Cherry-picked from releases/3.27.1-bigsur