### PR TITLE
Windows minicoda package: use OpenBLAS instead of MLK

### DIFF
--- a/ci/appveyor-conda-build.bat
+++ b/ci/appveyor-conda-build.bat
@@ -62,6 +62,7 @@ if "%CONDA_SPEC_FILE%" == "" (
                  bottleneck=1.3.* ^
                  pyqt=5.12.* ^
                  Orange3=%VERSION% ^
+                 blas=*=openblas ^
         || exit /b !ERRORLEVEL!
 
     "%CONDA%" list -n env --export --explicit --md5 > env-spec.txt

--- a/ci/appveyor-conda-build.bat
+++ b/ci/appveyor-conda-build.bat
@@ -57,7 +57,7 @@ if "%CONDA_SPEC_FILE%" == "" (
     "%CONDA%" create -n env --yes --use-local ^
                  python=%PYTHON_VERSION% ^
                  numpy=1.16.* ^
-                 scipy=1.2.* ^
+                 scipy=1.5.* ^
                  scikit-learn=0.23.* ^
                  bottleneck=1.3.* ^
                  pyqt=5.12.* ^

--- a/ci/appveyor-conda-build.bat
+++ b/ci/appveyor-conda-build.bat
@@ -50,6 +50,10 @@ if not "%BUILD_LOCAL%" == "" (
 echo VERSION = %VERSION%
 
 if "%CONDA_SPEC_FILE%" == "" (
+    rem # prefer conda forge
+    "%CONDA%" config --add channels conda-forge  || exit /b !ERRORLEVEL!
+    "%CONDA%" config --set channel_priority strict
+
     "%CONDA%" create -n env --yes --use-local ^
                  python=%PYTHON_VERSION% ^
                  numpy=1.16.* ^


### PR DESCRIPTION
Works with 3.27.1, not with maste: https://github.com/markotoplak/orange3-installers/tree/no-conda-main-mkl

Fixes biolab/orange3#5135

I suspect something else breaks the installers for master.