### PR TITLE
Add xgboost and catboost to PY36.

### DIFF
--- a/specs/win/PY36.txt
+++ b/specs/win/PY36.txt
@@ -26,3 +26,5 @@ serverfiles
 opentsne~=0.4.3
 python-louvain>=0.13
 pandas~=1.1.0
+catboost
+xgboost


### PR DESCRIPTION
Both catboost and xgboost can be installed via PIP on any OS so I am adding them to PY36 requirements