### PR TITLE
Enable xgboost conda requirement on windows

### DIFF
--- a/specs/conda-recipe/meta.yaml
+++ b/specs/conda-recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - cachecontrol   >=0.12.6
     - msgpack-python >=1.0
     - catboost
-    - xgboost       # [not win]
+    - xgboost
 
 test:
   # Python imports


### PR DESCRIPTION
Conda distribution of `xgboost` was not available for Windows before. Since we made it available now, I am removing the constraint.