### PR TITLE
[FIX] conda-installers: Setup shortcuts to ignore user site packages

### DIFF
--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -567,13 +567,13 @@ Section -Launchers
     # Startup shortcut
     CreateShortCut \
         "$InstDir\${LAUNCHER_SHORTCUT_NAME}.lnk" \
-        "$PythonExecPrefix\pythonw.exe" "-m ${LAUNCHERMODULE}" \
+        "$PythonExecPrefix\pythonw.exe" "-s -m ${LAUNCHERMODULE}" \
         "$PythonPrefix\share\${ICONDIR}\${APPICON}" 0
     # Utility shortcut to launch the application with max log level attached
     # to the console that remains visible after exit
     CreateShortCut \
         "$InstDir\${LAUNCHER_SHORTCUT_NAME} Debug.lnk" \
-        "%COMSPEC%" '/K "$PythonExecPrefix\python.exe" -m ${LAUNCHERMODULE} -l4' \
+        "%COMSPEC%" '/K "$PythonExecPrefix\python.exe" -s -m ${LAUNCHERMODULE} -l4' \
         "$PythonPrefix\share\${ICONDIR}\${APPICON}" 0
     # A utility shortcut for activating the environment
     CreateShortCut \
@@ -602,7 +602,7 @@ Section "Start Menu Shortcuts" SectionStartMenu
         CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
         CreateShortCut \
             "$SMPROGRAMS\$StartMenuFolder\${LAUNCHER_SHORTCUT_NAME}.lnk" \
-            "$PythonExecPrefix\pythonw.exe" "-m ${LAUNCHERMODULE}" \
+            "$PythonExecPrefix\pythonw.exe" "-s -m ${LAUNCHERMODULE}" \
             "$PythonPrefix\share\${ICONDIR}\${APPICON}" 0
 
         # A utility shortcut for activating the environment
@@ -623,10 +623,10 @@ Function StartMenuPre
 FunctionEnd
 
 Section "Desktop Shortcuts" SectionDesktop
-    DetailPrint "Installing Desktop shortcurt"
+    DetailPrint "Installing Desktop shortcut"
     CreateShortCut \
         "$DESKTOP\${LAUNCHER_SHORTCUT_NAME}.lnk" \
-        "$PythonExecPrefix\pythonw.exe" "-m ${LAUNCHERMODULE}" \
+        "$PythonExecPrefix\pythonw.exe" "-s -m ${LAUNCHERMODULE}" \
         "$PythonPrefix\share\${ICONDIR}\${APPICON}" 0
 SectionEnd
 SectionGroupEnd
@@ -678,7 +678,7 @@ Section -Register SectionRegister
         "$PythonPrefix\share\${ICONDIR}\OrangeOWS.ico"
     WriteRegStr SHELL_CONTEXT \
         "Software\Classes\${INSTALL_REGISTRY_KEY}\Shell\Open\Command\" "" \
-        '"$PythonExecPrefix\pythonw.exe" -m ${LAUNCHERMODULE} "%1"'
+        '"$PythonExecPrefix\pythonw.exe" -s -m ${LAUNCHERMODULE} "%1"'
 
     WriteUninstaller "$InstDir\${UNINSTALL_EXEFILE}"
 
@@ -749,7 +749,7 @@ Function un.Register
 FunctionEnd
 
 Function LaunchApplication
-    ExecShell "open" "$PythonExecPrefix\pythonw.exe" "-m ${LAUNCHERMODULE}"
+    ExecShell "open" "$PythonExecPrefix\pythonw.exe" "-s -m ${LAUNCHERMODULE}"
 FunctionEnd
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN


### PR DESCRIPTION
### Issue

Ref: https://github.com/biolab/orange3/issues/5654

Packages installed in the user site packages can break the application environment for conda based envs.

### Changes

Setup launcher shortcuts to ignore user site packages.