### PR TITLE
conda installer: make version extraction tolerant to .conda

### DIFF
--- a/scripts/windows/build-conda-installer.sh
+++ b/scripts/windows/build-conda-installer.sh
@@ -364,16 +364,16 @@ if [[ "${ONLINE}" == yes ]]; then
     cat > "${BASEDIR}"/conda-spec.txt < "${ENV_SPEC_FILE}"
     # extract the orange version from env spec
     VERSION=$(cat < "${BASEDIR}"/conda-spec.txt |
-              grep -E 'orange3-.*tar.bz2' |
-              sed -e 's@^.*orange3-\([^-]*\)-.*tar.bz2.*@\1@')
+              grep -E '(^|.+/)orange3-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)' |
+              sed -n 's@.*orange3-\([^-]*\)-.*$@\1@p')
     PYTHON_VERSION=$(conda-env-spec-python-version \
                      < "${BASEDIR:?}"/conda-spec.txt)
 else
     conda-fetch-packages "${BASEDIR:?}"/conda-pkgs "${ENV_SPEC_FILE}"
     # extract the orange version from env spec
     VERSION=$(cat < "${BASEDIR:?}"/conda-pkgs/conda-spec.txt |
-              grep -E 'orange3-.*tar.bz2' |
-              cut -d "-" -f 2)
+              grep -E '(^|.+/)orange3-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)' |
+              sed -n 's@.*orange3-\([^-]*\)-.*$@\1@p')
     PYTHON_VERSION=$(conda-env-spec-python-version \
                      < "${BASEDIR:?}"/conda-pkgs/conda-spec.txt)
 fi


### PR DESCRIPTION
Cherry-picked from https://github.com/ales-erjavec/orange3-installers/tree/releases/3.34.0

I have tested this code both with .tar.gz and .conda lines in conda spec file.