### PR TITLE
Make dmg build succeed more often

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,13 @@ jobs:
         displayName: 'Use Python 3.9'
 
       - bash: |
-          wget https://github.com/create-dmg/create-dmg/archive/refs/tags/v1.0.10.tar.gz
-          tar -zxvf v1.0.10.tar.gz
-          cd create-dmg-1.0.10/
+          wget https://github.com/create-dmg/create-dmg/archive/refs/tags/v1.1.0.tar.gz
+          tar -zxvf v1.1.0.tar.gz
+          cd create-dmg-1.1.0/
           sed -i.bu 's/MAXIMUM_UNMOUNTING_ATTEMPTS=3/MAXIMUM_UNMOUNTING_ATTEMPTS=6/g' create-dmg
           cat create-dmg | grep MAXIMUM_UNMOUNTING_ATTEMPTS
+          sed -i.bu 's/exit_code != 16/exit_code == 1616/g' create-dmg
+          cat create-dmg | grep exit_code
           make install
           cd ..
         displayName: 'Install modified create-dmg (modified to allow longer detach timeouts)'

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -13,7 +13,7 @@ joblib==1.2.0
 chardet~=3.0
 keyring==10.3.1
 keyrings.alt==2.2
-AnyQt~=0.1.0
+AnyQt~=0.2.0
 
 # PyQt==5.12.3 requires python compiled for MacOS 10.13+ to work on MacOS 11.0
 PyQt5~=5.15.4


### PR DESCRIPTION
`createdmg` frequently is not able to unmount our big image. I modified its code so that it repeats the unmounting a few times regardless of the error that `hdiutil detach` returns.

Before I needed to restart the Mac build many times so that it occasionally succeeded. Now they seem more robust.