### PR TITLE
[MACOS] Build installer for MacOS-11+

### DIFF
--- a/scripts/macos/build-macos-app.sh
+++ b/scripts/macos/build-macos-app.sh
@@ -85,7 +85,7 @@ cp -a "${DIR}"/skeleton.app/Contents/{Resources,Info.plist.in} \
 # Layout a 'relocatable' python framework in the app directory
 "${DIR}"/python-framework.sh \
     --version "${PYTHON_VERSION}" \
-    --macos 10.9 \
+    --macos 11 \
     --install-certifi \
     "${APPDIR}"/Contents/Frameworks
 

--- a/scripts/macos/python-framework.sh
+++ b/scripts/macos/python-framework.sh
@@ -54,11 +54,11 @@ python-framework-fetch-pkg() {
     local version=${2:?}
     local macosver=${3:-10.6}
     local versiondir=${version%%[abrpc]*}  # strip alpha, beta, rc component
-    local filename=python-${version}-macosx${macosver}.pkg
+    local filename=python-${version}-macos${macosver}.pkg
     local url="https://www.python.org/ftp/python/${versiondir}/${filename}"
     mkdir -p "${cachedir}"
     if [[ -f "${cachedir}/${filename}" ]]; then
-        verbose 1 "python-${version}-macosx{macosver}.pkg is present in cache"
+        verbose 1 "python-${version}-macos{macosver}.pkg is present in cache"
         return 0
     fi
     local tmpfile=$(mktemp "${cachedir}/${filename}"-XXXX)
@@ -301,7 +301,7 @@ done
 python-framework-fetch-pkg ~/.cache/pkgs/ ${VERSION} ${MACOSVER}
 python-framework-extract-pkg \
     "${1:?"FRAMEWORKPATH argument is missing"}" \
-    ~/.cache/pkgs/python-${VERSION}-macosx${MACOSVER}.pkg
+    ~/.cache/pkgs/python-${VERSION}-macos${MACOSVER}.pkg
 
 python-framework-relocate "${1:?}"/Python.framework
 


### PR DESCRIPTION
Solving https://github.com/biolab/orange3/issues/6547

Use Python to build with MacOS SDK 11 (Big Sur). Older MacOSs are already end of life.