### PR TITLE
Disable notices in the conda installer

### DIFF
--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -7,6 +7,9 @@ set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
 
+rem Disable notices to prevent net access within the installer
+set CONDA_NUMBER_CHANNEL_NOTICES=0
+
 rem activate the root conda environment (miniconda3 4.7.0 installs
 rem libarchive that requires this - conda cannot be used as a executable
 rem without activation first)


### PR DESCRIPTION
I've seen two users with similar errors to biolab/orange3#6491 - crashing on `Retrieving notices: ...working... failed`. 

This notices are seemingly something new in conda. Both users that got this already had their anaconda installed. These notices are something that is intermittently shown to users, so I can replicate it easily, but I tried the same approach as with conda/conda#11743. 

This hopefully fixes biolab/orange3#6491