### PR TITLE
requirements-arm64: Bump Qt6 to 6.6 due to QTBUG-118992

### DIFF
--- a/specs/macos/requirements-arm64.txt
+++ b/specs/macos/requirements-arm64.txt
@@ -15,10 +15,10 @@ keyring~=23.0
 keyrings.alt~=4.0
 AnyQt~=0.2.0
 
-PyQt6~=6.5.0
-PyQt6-Qt6~=6.5.0
-PyQt6-WebEngine~=6.5.0
-PyQt6-WebEngine-Qt6~=6.5.0
+PyQt6~=6.6.0
+PyQt6-Qt6~=6.6.0
+PyQt6-WebEngine~=6.6.0
+PyQt6-WebEngine-Qt6~=6.6.0
 
 docutils~=0.18.0
 pip~=23.0.0


### PR DESCRIPTION
### Issue

Ref: https://github.com/biolab/orange3/issues/6695

### Changes

Bump Qt6 to 6.6 due to [QTBUG-118992](https://bugreports.qt.io/browse/QTBUG-118992)