### PR TITLE
Downgrade Qt to 5.12 in macos arm64 build

### DIFF
--- a/specs/macos/requirements-arm64.txt
+++ b/specs/macos/requirements-arm64.txt
@@ -15,10 +15,10 @@ keyring~=23.0
 keyrings.alt~=4.0
 AnyQt~=0.2.0
 
-PyQt6~=6.6.0
-PyQt6-Qt6~=6.6.0
-PyQt6-WebEngine~=6.6.0
-PyQt6-WebEngine-Qt6~=6.6.0
+PyQt5~=5.15.10
+PyQt5-Qt5~=5.15.12
+PyQtWebEngine~=5.15.6
+PyQtWebEngine-Qt5~=5.15.12
 
 docutils~=0.18.0
 pip~=23.0.0


### PR DESCRIPTION
Downgrade Qt to 5.12 in macos arm64 build

Due to [QTBUG-120469](https://bugreports.qt.io/browse/QTBUG-120469)