### PR TITLE
Python Installer - Call Python installer with same flag to InstallAllUsers and InstallLauncherAllUsers

### DIFF
--- a/scripts/windows/PythonHelpers.nsh
+++ b/scripts/windows/PythonHelpers.nsh
@@ -387,11 +387,15 @@ FunctionEnd
             StrCpy $1 "0"
         ${EndIf}
         ${If} ${Silent}
-            DetailPrint 'Executing: "${INSTALLER}" -quiet InstallAllUsers=$1'
-            nsExec::ExecToLog '"${INSTALLER}" -quiet InstallAllUsers=$1'
+            DetailPrint 'Executing: "${INSTALLER}" -quiet InstallAllUsers=$1 \
+                InstallLauncherAllUsers=$1'
+            nsExec::ExecToLog '"${INSTALLER}" -quiet InstallAllUsers=$1 \
+                InstallLauncherAllUsers=$1'
         ${Else}
-            DetailPrint 'Executing: "${INSTALLER}" InstallAllUsers=$1'
-            nsExec::ExecToLog '"${INSTALLER}" InstallAllUsers=$1'
+            DetailPrint 'Executing: "${INSTALLER}" InstallAllUsers=$1 \
+                InstallLauncherAllUsers=$1'
+            nsExec::ExecToLog '"${INSTALLER}" InstallAllUsers=$1 \
+                InstallLauncherAllUsers=$1'
         ${EndIf}
     ${Else}
         Abort "PyInstall Error: ${INSTALLER} - invalid filename (extension)"


### PR DESCRIPTION
##### Issue

When Python is installed for current users only (InstallAllUsers=0), Python Launcher still wants to be installed for all users. Checkbox `Use admin privileges when installing py.exe` is checked. It shouldn't be checked since InstallAllUsers=0 is used in cases when the user doesn't have admin privileges, and if they don't uncheck it manually, installation will fail.

##### Changes

Use the same value for InstallAllUsers and InstallLauncherAllUsers, which will install:
- if 1 will install Python and Launcher for all users
- if 0, will install Python and Launcher only for the current user