### PR TITLE
[MNT] Update os runners

### DIFF
--- a/.github/workflows/build-conda-installer.yml
+++ b/.github/workflows/build-conda-installer.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - os: macos-11
+          - os: macos-12
             arch: x86_64
             python-version: "3.10.11"
             req: ../specs/macos/requirements.txt
@@ -157,7 +157,7 @@ jobs:
       matrix:
         # Repeat of above build step runner definitions
         include:
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
           - os: macos-14
             arch: arm64

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -57,7 +57,7 @@ jobs:
           git checkout $BUILD_COMMIT
 
       - name: Setup Pip Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('.github/workflows/build-macos-installer.yml') }}

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -51,7 +51,7 @@ jobs:
           git checkout $BUILD_COMMIT
 
       - name: Setup Pip Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('.github/workflows/build-win-installer.yml') }}

--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -51,7 +51,7 @@ jobs:
           git checkout $BUILD_COMMIT
 
       - name: Setup Pip Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('.github/workflows/build-win-portable.yml') }}


### PR DESCRIPTION

* macos-latest changed from x86_64 to arm64 causing macos x86_64 test to fail
* macos-11 is deprecated

Also update deprecated  actions 