### PR TITLE
conda: remove defaults channel

### DIFF
--- a/.github/workflows/build-conda-installer.yml
+++ b/.github/workflows/build-conda-installer.yml
@@ -50,7 +50,6 @@ jobs:
           condarc: >-
             channels:
               - conda-forge
-              - defaults
           environment-name: build
           create-args: conda conda-build boa python=3.11
           init-shell: bash cmd.exe

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -33,7 +33,6 @@ rem # We need it so add-ons can be installed from conda-forge
 echo Appending conda-forge channel
 echo channels:         > "%PREFIX%\.condarc"
 echo   - conda-forge  >> "%PREFIX%\.condarc"
-echo   - defaults     >> "%PREFIX%\.condarc"
 
 rem Path to base conda env
 for /f %%f in ( '"%CONDA%" info --root' ) do (


### PR DESCRIPTION
Ensures https://github.com/biolab/orange3/issues/6888 won't happen.

Our packages were already all from conda-forge. This PR altogether removes references to the defaults channel so that a package with a potentially problematic licenses won't creep back in.