### PR TITLE
Use Qt 6 in all installers where available

### DIFF
--- a/.github/workflows/build-conda-installer.yml
+++ b/.github/workflows/build-conda-installer.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       REPO: https://github.com/biolab/orange3.git
       BUILD_BRANCH: master
-      BUILD_COMMIT: "3.37.0"
+      BUILD_COMMIT: "3.38.1"
       BUILD_LOCAL: ""
 
       PYTHONFAULTHANDLER: 1
@@ -30,7 +30,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - python-version: "3.11.8"
+          - python-version: "3.11"
             miniforge-version: "24.7.1-0"
 
     defaults:

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - os: macos-12
+          - os: macos-13
             arch: x86_64
             python-version: "3.10.11"
             req: ../specs/macos/requirements.txt

--- a/scripts/windows/build-win-installer.sh
+++ b/scripts/windows/build-win-installer.sh
@@ -378,7 +378,7 @@ package-requirements "${PIP_ARGS[@]}"
 cp "${DIRNAME}"/{"Orange.ico","OrangeOWS.ico"} "${BASEDIR:?}/icons"
 
 shopt -s failglob
-WHEEL=( "${BASEDIR}"/wheels/${NAME}*.whl )
+WHEEL=( "${BASEDIR}"/wheels/orange3*.whl )
 shopt -u failglob
 
 if [[ ! "${WHEEL}" ]]; then

--- a/specs/macos/requirements-arm64.txt
+++ b/specs/macos/requirements-arm64.txt
@@ -15,10 +15,10 @@ keyring~=23.0
 keyrings.alt~=4.0
 AnyQt~=0.2.0
 
-PyQt6~=6.6.1
-PyQt6-Qt6~=6.6.3
-PyQt6-WebEngine~=6.6.0
-PyQt6-WebEngine-Qt6~=6.6.3
+PyQt6~=6.8.1
+PyQt6-Qt6~=6.8.1
+PyQt6-WebEngine~=6.8.0
+PyQt6-WebEngine-Qt6~=6.8.1
 
 docutils~=0.18.0
 pip~=23.3.1

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -15,8 +15,11 @@ keyring~=23.0
 keyrings.alt~=4.0
 AnyQt~=0.2.0
 
-PyQt5~=5.15.4
-pyqtwebengine~=5.15.4
+# oldest supported macos Big Sur
+PyQt6~=6.5.2
+PyQt6-Qt6~=6.5.2
+PyQt6-WebEngine~=6.5.0
+PyQt6-WebEngine-Qt6~=6.5.2
 
 docutils~=0.18.0
 pip~=23.3.1

--- a/specs/win/requirements.txt
+++ b/specs/win/requirements.txt
@@ -14,8 +14,10 @@ keyring~=23.0
 keyrings.alt~=4.0
 AnyQt~=0.2.0
 
-PyQt5~=5.15.3
-pyqtwebengine~=5.15.1
+PyQt6~=6.8.1
+PyQt6-Qt6~=6.8.1
+PyQt6-WebEngine~=6.8.0
+PyQt6-WebEngine-Qt6~=6.8.1
 
 docutils~=0.18.0
 pip~=24.0.0


### PR DESCRIPTION
Use Qt 6 in all installers where available

The only missing is the conda env based because PyQt6 is not available on conda-forge