### PR TITLE
[FIX] Windows Portable shortcuts

### DIFF
--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -107,6 +107,18 @@ jobs:
         shell: bash
         run: |
           7z x "-oD:\\test-install" Orange*.zip
+
+      - name: Read back shortcut
+        shell: pwsh
+        run: |
+          $WScriptShell = New-Object -ComObject WScript.Shell
+          $shortcut = $WScriptShell.CreateShortcut('D:\\test-install\\Orange\\Orange.lnk')
+          echo "Target:" $shortcut.TargetPath
+          echo "Arguments:" $shortcut.Arguments
+          $shortcut = $WScriptShell.CreateShortcut('D:\\test-install\\Orange\\Orange Debug.lnk')
+          echo "Target:" $shortcut.TargetPath
+          echo "Arguments:" $shortcut.Arguments
+
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Prepare wheels
         shell: bash
+        env:
+          MSYS2_ARG_CONV_EXCL: "*"
         run: |
           python -m pip install $BUILD_DEPS
           if [[ $BUILD_LOCAL ]]; then
@@ -74,6 +76,7 @@ jobs:
         shell: bash
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          MSYS2_ARG_CONV_EXCL: "*"
         run: |
           export PATH="$(cygpath -u C:\\msys64\\usr\\bin):$PATH"
           echo PATH=$PATH

--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -16,8 +16,8 @@ jobs:
     env:
       REPO: https://github.com/biolab/orange3.git
       BUILD_BRANCH: master
-      BUILD_COMMIT: FETCH_HEAD
-      BUILD_LOCAL: 1
+      BUILD_COMMIT: "3.38.1"
+      BUILD_LOCAL: ""
 
       PYTHONFAULTHANDLER: 1
       PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/scripts/windows/build-win-portable.sh
+++ b/scripts/windows/build-win-portable.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# !/usr/bin/env bash
 
 NAME=Orange3
 
@@ -11,6 +11,8 @@ PIP_ARGS=()
 
 PYTHON_VERSION=${PYTHON_VERSION:-"3.10.11"}
 
+# Suppress MSYS2 auto unix -> win path expansion
+export MSYS2_ARG_CONV_EXCL="*"
 
 while [[ "${1:0:1}" = "-" ]]; do
     case $1 in

--- a/scripts/windows/build-win-portable.sh
+++ b/scripts/windows/build-win-portable.sh
@@ -98,20 +98,20 @@ BUILDDIR_WIN="$(cygpath -w "${BUILDDIR}")"
 
 python -m pip install pywin32
 python "${DIR}/create_shortcut.py" \
-   --target 'cmd.exe' \
+   --target '%SystemRoot%\\system32\\cmd.exe' \
    --arguments '"/C start pythonw.exe -Psm Orange.canvas"' \
    --working-directory "" \
    --window-style Minimized \
    --shortcut "${BUILDDIR_WIN}\Orange.lnk"
 
 python "${DIR}/create_shortcut.py" \
-   --target 'cmd.exe' \
+   --target '%SystemRoot%\\system32\\cmd.exe' \
    --arguments '"/K python.exe -Psm Orange.canvas -l4"' \
    --working-directory "" \
    --shortcut "${BUILDDIR_WIN}/Orange Debug.lnk"
 
 python "${DIR}/create_shortcut.py" \
-   --target 'cmd.exe' \
+   --target '%SystemRoot%\\system32\\cmd.exe' \
    --arguments '"/C start Orange\pythonw.exe -Psm Orange.canvas"' \
    --working-directory "" \
    --window-style Minimized \


### PR DESCRIPTION
Startup shortcuts in windows portable installers are wrong due to MSYS2 bash path mangling.
I.e. "/C start pythonw.exe ..." in shortcut's arguments list is expanded to "C:/msys64/C start pythonw.exe ..."