### PR TITLE
Update Windows build machine to windows-2022

### DIFF
--- a/.github/workflows/build-conda-installer.yml
+++ b/.github/workflows/build-conda-installer.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on:  windows-2019
+    runs-on:  windows-2022
     timeout-minutes: 60
     env:
       REPO: https://github.com/biolab/orange3.git
@@ -128,7 +128,7 @@ jobs:
   test:
     name: Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       INSTALL_PATH: "D:\\install path"
     steps:

--- a/.github/workflows/build-win-installer.yml
+++ b/.github/workflows/build-win-installer.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on:  windows-2019
+    runs-on:  windows-2022
     timeout-minutes: 30
     env:
       REPO: https://github.com/biolab/orange3.git
@@ -99,7 +99,7 @@ jobs:
   test:
     name: Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Download installer
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -81,7 +81,7 @@ jobs:
           export PATH="$(cygpath -u C:\\msys64\\usr\\bin):$PATH"
           echo PATH=$PATH
           mkdir dist
-          
+          pacman -S --noconfirm zip
           ./scripts/windows/build-win-portable.sh  --no-index --find-links=./wheels  --python-version $PYTHON_VERSION --pip-arg=--pre --pip-arg=-r --pip-arg=$ENVSPEC --pip-arg=Orange3
 
           INSTALLER=( dist/Orange*.zip )

--- a/.github/workflows/build-win-portable.yml
+++ b/.github/workflows/build-win-portable.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on:  windows-2019
+    runs-on:  windows-2022
     timeout-minutes: 30
     env:
       REPO: https://github.com/biolab/orange3.git
@@ -99,7 +99,7 @@ jobs:
   test:
     name: Test
     needs: build
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Download installer
         uses: actions/download-artifact@v4


### PR DESCRIPTION
windows-2019 was deprecated.

This just upgrades the version hoping that the build process survives.