### PR TITLE
[MNT] build-macos-installer.yml: Update Python to 3.11 in intel installer

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - os: macos-15-intel
             arch: x86_64
-            python-version: "3.10.11"
+            python-version: "3.11.8"
             req: ../specs/macos/requirements.txt
             app: "/Applications/Orange3.app"
           - os: macos-14

--- a/specs/macos/requirements.txt
+++ b/specs/macos/requirements.txt
@@ -31,4 +31,4 @@ opentsne~=1.0.0
 python-louvain>=0.13
 pandas~=1.5.0
 xgboost
-catboost~=1.1.1  # catboost 1.2 wheels do not support macos <11
+catboost~=1.2.2


### PR DESCRIPTION
Use Python 3.11 in macos intel installer