### PR TITLE
[ENH] Provide MSVC Runtime for micromamba

### DIFF
--- a/scripts/windows/build-conda-installer.sh
+++ b/scripts/windows/build-conda-installer.sh
@@ -49,6 +49,8 @@ CACHEDIR=
 MICROMAMBA_VERSION_DEFAULT=1.5.1-0
 MICROMAMBA_VERSION=${MICROMAMBA_VERSION_DEFAULT}
 
+MSVC_REDIST_VERSION=${MSVC_REDIST_VERSION:-14.44.35112}
+
 PLATTAG=win_amd64
 
 # online or offline installer.
@@ -373,8 +375,15 @@ if [[ ! "${PYTHON_VERSION}" ]]; then
     exit 1;
 fi
 
+mkdir "${BASEDIR:?}/micromamba"
 cp "${CACHEDIR:?}/micromamba/micromamba-${MICROMAMBA_VERSION}-win-64" \
-   "${BASEDIR:?}/micromamba.exe"
+   "${BASEDIR:?}/micromamba/micromamba.exe"
+
+pip download --dest="${CACHEDIR:?}/msvc_runtime" --platform=win_amd64 --no-deps msvc-runtime==${MSVC_REDIST_VERSION:?}
+7z e -o"${BASEDIR:?}/micromamba" "${CACHEDIR:?}/msvc_runtime/msvc_runtime-${MSVC_REDIST_VERSION:?}-*.whl" \
+    "*/data/msvcp140.dll" \
+    "*/data/Scripts/vcruntime140.dll" \
+    "*/data/Scripts/vcruntime140_1.dll"
 
 mkdir -p "${BASEDIR:?}/icons"
 cp "$(dirname "$0")"/{Orange.ico,OrangeOWS.ico} "${BASEDIR:?}/icons"

--- a/scripts/windows/conda.bat
+++ b/scripts/windows/conda.bat
@@ -1,3 +1,3 @@
 @echo off
 set "__PREFIX=%~dp0\.."
-"%__PREFIX%\micromamba.exe" --root-prefix "%__PREFIX%" --prefix "%__PREFIX%" %*
+"%__PREFIX%\.micromamba\micromamba.exe" --root-prefix "%__PREFIX%" --prefix "%__PREFIX%" %*

--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -385,6 +385,18 @@ FunctionEnd
 Section "-Micromamba" SectionMicromamba
     DetailPrint "Installing micromamba.exe"
     ${ExtractTemp} "${BASEDIR}\micromamba.exe" "$InstDir"
+    ${ExecToLog} '"$InstDir\micromamba.exe" --help'
+    Pop $0
+    ${If} $0 != 0
+        Delete $InstDir\micromamba.exe
+        MessageBox MB_OK '\
+            "micromamba" command exited with an error code $0.$\r$\n\
+            Most likely reason for this is a missing or obsolete \
+            "Microsoft Visual C++ Redistributable" package.$\r$\n\
+            Please install the latest from https://aka.ms/vc14/vc_redist.x86.exe\
+        '
+        Abort "micromamba.exe exited with $0. Cannot continue"
+    ${EndIf}
 SectionEnd
 
 Function un.Micromamba

--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -384,11 +384,12 @@ FunctionEnd
 # A Micromamba executable
 Section "-Micromamba" SectionMicromamba
     DetailPrint "Installing micromamba.exe"
-    ${ExtractTemp} "${BASEDIR}\micromamba.exe" "$InstDir"
-    ${ExecToLog} '"$InstDir\micromamba.exe" --help'
+    ${ExtractTempRec} "${BASEDIR}\micromamba\*.*" "$InstDir\.micromamba"
+    StrCpy $Micromamba "$InstDir\.micromamba\micromamba.exe"
+    ${ExecToLog} '"$Micromamba" --help'
     Pop $0
     ${If} $0 != 0
-        Delete $InstDir\micromamba.exe
+        RMDir /r $InstDir\.micromamba
         MessageBox MB_OK '\
             "micromamba" command exited with an error code $0.$\r$\n\
             Most likely reason for this is a missing or obsolete \
@@ -400,7 +401,7 @@ Section "-Micromamba" SectionMicromamba
 SectionEnd
 
 Function un.Micromamba
-    Delete "$InstDir\micromamba.exe"
+    RMDir /r "$InstDir\.micromamba"
 FunctionEnd
 
 
@@ -447,7 +448,7 @@ Section "Install required packages" InstallPackages
     SetDetailsPrint none
     SetOutPath "${TEMPDIR}"
     SetDetailsPrint both
-    StrCpy $Micromamba "$InstDir\micromamba.exe"
+
     DetailPrint "Creating an conda env"
     # Just make sure that conda-meta dir is present, this is the minimum
     # required to work. micromamba create refuses to create an env that is the
@@ -496,7 +497,7 @@ Function un.InstallPackages
     ${AndIf} ${FileExists} "$InstDir\${UNINSTALL_EXEFILE}"
         DetailPrint "Removing all packages"
         ${ExecToLog} '\
-            "$InstDir\micromamba.exe" remove \
+            "$InstDir\.micromamba\micromamba.exe" remove \
                 --root-prefix "$InstDir" \
                 --all --yes --prefix "$InstDir" \
             '


### PR DESCRIPTION
### Issue

Installation (micromamba) fails if  Microsoft Visual C++ Redistributable package is not installed or is too old.

Fixes https://github.com/biolab/orange3/issues/7165

<s>This PR is build on top of https://github.com/biolab/orange3-installers/pull/68 which should be merged first.</s>

### Changes

Isolate micromamba and provide MSVC Runtime dlls for micromamba